### PR TITLE
Closes #1 - Fix clock animation in Google Colab

### DIFF
--- a/lispy.ipynb
+++ b/lispy.ipynb
@@ -1612,8 +1612,8 @@
     "        (display (car (cdr (now))))\n",
     "        (display (quote :))\n",
     "        (display (car (cdr (cdr (now)))))\n",
-    "        (return)\n",
     "        (sleep 1)\n",
+    "        (return)\n",
     "        (clock))))\n",
     "\n",
     "(if 0 (clock) 0)"


### PR DESCRIPTION
Este PR altera a definição do comando `(clock)` para prover uma usabilidade mínima no Google Colab, mantendo a compatibilidade com o Jupyter Local.

A implementação utilizada segue a opção de mudar o uso do `(sleep)`, conforme sugerido em #1.


https://github.com/ramalho/lispyse24/assets/8387736/eced492e-d435-4253-a1be-86a2546c6124

